### PR TITLE
Pass completion handler through

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -411,7 +411,7 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
           localizedCallerName:(NSString * _Nullable)localizedCallerName
                   fromPushKit:(BOOL)fromPushKit
                       payload:(NSDictionary * _Nullable)payload
-        withCompletionHandler:(void (^_Nullable)(void))completion
+        withCompletionHandler:(void (^)(void))completion
 {
     [RNCallKeep reportNewIncomingCall:uuidString handle:handle handleType:handleType hasVideo:hasVideo localizedCallerName:localizedCallerName fromPushKit:fromPushKit payload:payload withCompletionHandler:completion resolver:nil rejecter:nil];
 }

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -413,7 +413,7 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
                       payload:(NSDictionary * _Nullable)payload
         withCompletionHandler:(void (^_Nullable)(void))completion
 {
-    [RNCallKeep reportNewIncomingCall:uuidString handle:handle handleType:handleType hasVideo:hasVideo localizedCallerName:localizedCallerName fromPushKit:fromPushKit payload:payload withCompletionHandler:nil resolver:nil rejecter:nil];
+    [RNCallKeep reportNewIncomingCall:uuidString handle:handle handleType:handleType hasVideo:hasVideo localizedCallerName:localizedCallerName fromPushKit:fromPushKit payload:payload withCompletionHandler:completion resolver:nil rejecter:nil];
 }
 
 + (void)reportNewIncomingCall:(NSString *)uuidString


### PR DESCRIPTION
In #1, the completion handler was lost in one of the overloaded methods. Also, make the completion argument for that overload not nullable.